### PR TITLE
Add Plop web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # reasoning
 Play around with AI reasoning models 🧠
+
+## Plop app
+A tiny HTML/JS demo lives at `plop/index.html`. Open it in a browser and click the button to see it plop.

--- a/plop/index.html
+++ b/plop/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Plop</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    #message { font-size: 1.5rem; margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Plop</h1>
+  <button id="plop-btn">Plop it!</button>
+  <div id="message"></div>
+  <script>
+    document.getElementById('plop-btn').addEventListener('click', function () {
+      document.getElementById('message').textContent = 'Plop!';
+    });
+  </script>
+</body>
+</html>

--- a/tests/test_plop.py
+++ b/tests/test_plop.py
@@ -1,0 +1,12 @@
+import pathlib
+
+
+def test_plop_title():
+    html = pathlib.Path("plop/index.html").read_text(encoding="utf-8")
+    assert "<title>Plop</title>" in html
+
+
+def test_plop_button_and_message():
+    html = pathlib.Path("plop/index.html").read_text(encoding="utf-8")
+    assert "plop-btn" in html
+    assert "Plop!" in html


### PR DESCRIPTION
## Summary
- add a minimal Plop HTML/JS demo
- cover page title and button behavior with tests
- document the Plop app in the README

## Testing
- `ruff check .`
- `pytest -q`
- `python -m streamlit hello`


------
https://chatgpt.com/codex/tasks/task_e_68bd1d90c938832d9b0fc20f9ec4b2f1