### PR TITLE
Add Plop bubble game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # reasoning
 Play around with AI reasoning models 🧠
+
+## Plop app
+A bubbly HTML/JS mini-game lives at `plop/index.html`. Open it in a browser to pop rising bubbles and chase a high score.
+

--- a/plop/index.html
+++ b/plop/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Plop Bubble Game</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+      height: 100%;
+    }
+    body {
+      background: radial-gradient(circle at top, #0af, #036);
+      font-family: sans-serif;
+    }
+    #score {
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      color: white;
+      font-size: 1.2rem;
+      z-index: 1;
+    }
+    canvas { display: block; }
+  </style>
+</head>
+<body>
+  <div id="score">Score: 0</div>
+  <canvas id="game"></canvas>
+  <script>
+    const canvas = document.getElementById('game');
+    const ctx = canvas.getContext('2d');
+    let score = 0;
+    function resize() {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    }
+    window.addEventListener('resize', resize);
+    resize();
+
+    const bubbles = [];
+    function spawnBubble() {
+      const radius = Math.random() * 30 + 10;
+      const x = Math.random() * (canvas.width - radius * 2) + radius;
+      const y = canvas.height + radius;
+      const speed = Math.random() * 1 + 0.5;
+      bubbles.push({x, y, radius, speed});
+    }
+
+    function drawBubble(b) {
+      const grad = ctx.createRadialGradient(b.x - b.radius/3, b.y - b.radius/3, b.radius/5, b.x, b.y, b.radius);
+      grad.addColorStop(0, '#ffffffaa');
+      grad.addColorStop(1, '#00aaffdd');
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.arc(b.x, b.y, b.radius, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    function update() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      for (let i = bubbles.length - 1; i >= 0; i--) {
+        const b = bubbles[i];
+        b.y -= b.speed;
+        drawBubble(b);
+        if (b.y + b.radius < 0) bubbles.splice(i,1);
+      }
+      requestAnimationFrame(update);
+    }
+
+    canvas.addEventListener('click', (e) => {
+      const rect = canvas.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      for (let i = bubbles.length - 1; i >= 0; i--) {
+        const b = bubbles[i];
+        const dx = b.x - x;
+        const dy = b.y - y;
+        if (Math.hypot(dx, dy) < b.radius) {
+          bubbles.splice(i,1);
+          score++;
+          document.getElementById('score').textContent = `Score: ${score}`;
+          break;
+        }
+      }
+    });
+
+    setInterval(spawnBubble, 800);
+    update();
+  </script>
+</body>
+</html>

--- a/tests/test_plop.py
+++ b/tests/test_plop.py
@@ -1,0 +1,12 @@
+import pathlib
+
+
+def test_plop_title():
+    html = pathlib.Path("plop/index.html").read_text(encoding="utf-8")
+    assert "<title>Plop Bubble Game</title>" in html
+
+
+def test_canvas_and_score():
+    html = pathlib.Path("plop/index.html").read_text(encoding="utf-8")
+    assert '<canvas id="game">' in html
+    assert 'id="score"' in html


### PR DESCRIPTION
## Summary
- convert Plop demo into a canvas-based bubble popping game
- display live score and animated bubbles that float upward
- document the game in the README and update tests

## Testing
- `ruff check .`
- `pytest -q`
- `python -m streamlit hello`


------
https://chatgpt.com/codex/tasks/task_e_68bd1d90c938832d9b0fc20f9ec4b2f1